### PR TITLE
Get rid of sidekiq

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -8,7 +8,7 @@ require "capistrano/deploy"
 # Use bundler to install gem requirements
 require 'capistrano/bundler'
 require 'capistrano/rails'
-require 'capistrano/sidekiq'
+# require 'capistrano/sidekiq'
 require 'capistrano/passenger'
 require "capistrano/scm/git"
 install_plugin Capistrano::SCM::Git

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -47,4 +47,4 @@ append :linked_files, "config/secrets.yml"
 # Default branch is :master
 set :branch, ENV['REVISION'] || ENV['BRANCH'] || ENV['BRANCH_NAME'] || 'master'
 
-after "deploy:restart", "sidekiq:restart"
+# after "deploy:restart", "sidekiq:restart"


### PR DESCRIPTION
We don't need sidekiq for this proof of concept rails app so commenting references to it out in the cap deploy process. 