### PR TITLE
updated cookies: domain to library.ucla.edu and expire to 90 days

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,7 +48,11 @@ class ApplicationController < ActionController::Base
   end
 
   def set_iv_cookie
-    cookies[:initialization_vector] = { value: @iv }
+    cookies[:initialization_vector] = {
+      value: @iv,
+      expires: Time.now + 90.days,
+      domain: ENV['DOMAIN']
+    }
   end
 
   def create_encrypted_string

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       SINAIID_UCLA_KEY: 'cfa59195dbbb31094beda066891bf5112be0f15e161834c4a8f4b2237a5bfae4'
       SINAIID_URL: 'https://sinai-id.org/authorize'
-      DOMAIN: 'localhost:3030'
+      DOMAIN: 'library.ucla.edu'
     env_file:
       - ./default.env
       - ./docker.env


### PR DESCRIPTION
This syncs the cookies for expiration. Changing the domain setting to library.ucla.edu is aimed at fixing a generic server error on https://d-w-sinaiauth01.library.ucla.edu/