### PR TITLE
[IIIF-526] Make cipher_text cookie friendly

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -63,10 +63,10 @@ end
     cipher.encrypt
     @iv = cipher.random_iv
     @iv = "abcdefghijklmnop"
-    # cipher.key = OpenSSL::Random.random_bytes(32)
     cipher.key = ENV['CIPHER_KEY']
     cipher.iv = @iv
     @cipher_text = cipher.update("Authenticated #{todays_date}") + cipher.final
+    @cipher_text = @cipher_text.unpack('H*')[0].upcase
   end
 end
 


### PR DESCRIPTION
The cipher_text gets mangled when put into a cookie. If we convert it to a string first then it can be stored and retrieved more easily.